### PR TITLE
不要なインストールパッケージを削除

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,3 @@ django-filter
 django-cors-headers
 googletrans==4.0.0-rc1
 openai
-os
-logging
-TimedRotatingFileHandler


### PR DESCRIPTION
Pythonデフォルトのパッケージはインストール設定不要