### PR TITLE
[Reviewed] pytestの実装、および質問処理のエラーハンドリングの追加と質問内容を修正

### DIFF
--- a/backend/chatgptapi/services/chatgpt.py
+++ b/backend/chatgptapi/services/chatgpt.py
@@ -2,7 +2,6 @@
 from logging.handlers import TimedRotatingFileHandler
 from django.conf import settings
 from googletrans import Translator
-import os
 import openai
 import json
 import logging
@@ -52,20 +51,25 @@ def createPrompt(request):
 
     # JSONファイルの読み込み及び取得
     # 言語
-    programming_language_open = open('./json/programmingLanguage.json', 'r')
-    programming_language_json = json.load(programming_language_open)
+    with open('./json/programmingLanguage.json', 'r', encoding='utf-8') as programming_language_open:
+        programming_language_json = json.load(programming_language_open)
     programming_language = getPrompt(programming_language_json, "lang", int(prompt["programmingLanguage"]))
+    if programming_language == "":
+        return "存在しない言語です。入力内容を確認してください。"
+
     # プラットフォーム
-    platform_open = open('./json/platform.json', 'r')
-    platform_json = json.load(platform_open)
+    with open('./json/platform.json', 'r', encoding='utf-8') as platform_open:
+        platform_json = json.load(platform_open)
     platform = getPrompt(platform_json, "platform", int(prompt["platform"]))
+    if platform == "":
+        return "存在しないプラットフォームです。入力内容を確認してください。"
     
     # system_prompt
-    system_prompt1 = " 「作りたいアプリの概要：」で指定されたアプリを「プラットフォーム：」と「プログラム言語：」に指定された条件で構築する際、お勧めのフレームワーク名を最大３つまで提案してください。\n"
+    system_prompt1 = " 「作りたいアプリの概要：」で指定された内容を「プラットフォーム：」と「プログラム言語：」に指定された条件で構築する際、お勧めのフレームワーク名を最大３つまで提案してください。\n"
     system_prompt2 = "また、提案された各フレームワークの「開発環境」を簡潔に教えてください。\n"
-    system_prompt3 = "「DB使用有無：」が「有り」となっていた場合、「DB使用」を考慮したライブラリを、「クラウド使用有無：」が「有り」となっていた場合は「クラウド使用」を考慮したライブラリを紹介してください。\n"
-    system_prompt_template = "回答は＜テンプレート＞の内容に沿って返却してください。\n ＜テンプレート＞ \n フレームワーク名： \n  開発環境： \n"
-    system_prompt_ehd = "それ以外の回答はしないでください。\n 「作りたいアプリの概要：」で回答できない質問を指定された場合は、「アプリが不明です。」と返答してください。 \n 「プログラム言語：」に存在しない言語を質問されたら「存在しない言語です。入力内容を確認してください。」と回答してください。\n"
+    system_prompt3 = "「DB使用有無：」が「有り」の場合、「DB使用」を考慮したライブラリを、「クラウド使用有無：」が「有り」となっていの場合は「クラウド使用」を考慮したライブラリを紹介してください。\n"
+    system_prompt_template = "回答は＜テンプレート＞の内容に沿って返却してください。\n ＜テンプレート＞ \n フレームワーク名： \n  開発環境： \n  ライブラリ： \n"
+    system_prompt_ehd = "それ以外の回答はしないでください。\n 「作りたいアプリの概要：」で回答できない質問を指定された場合は、「アプリが不明です。」と返答してください。"
     system_prompt = system_prompt1 + system_prompt2 + system_prompt3 + system_prompt_template + system_prompt_ehd
     logger.debug("system_prompt:\n" + system_prompt)
     # user_prompt

--- a/backend/chatgptapi/test/pytest_chatgpt.py
+++ b/backend/chatgptapi/test/pytest_chatgpt.py
@@ -1,0 +1,117 @@
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock
+from chatgptapi.services.chatgpt import createPrompt
+
+# 環境変数とDjangoの設定
+os.environ['DJANGO_SETTINGS_MODULE'] = 'devchatrecipe.settings'
+sys.path.append('/backend/chatgptapi')
+
+# Djangoのセットアップ
+import django
+django.setup()
+
+MAX_LEN = 50
+
+# テスト関数
+def test_createPrompt_normal():
+    # モックの設定
+    request_data = {
+        "prompt": {
+            "appOverview": "test app",
+            "programmingLanguage": 1,
+            "platform": 2,
+            "useDatabase": "true",
+            "useCloud": "true"
+        }
+    }
+    request = MagicMock()
+    request.data = request_data
+
+    # テスト対象の実行
+    result = createPrompt(request)
+
+    # 結果の検証
+    assert result is not None
+
+def test_createPrompt_abnormal():
+    # モックの設定
+    request_data = {
+        "prompt": {
+            "appOverview": "",
+            "programmingLanguage": 1,
+            "platform": 2,
+            "useDatabase": "true",
+            "useCloud": "true"
+        }
+    }
+    request = MagicMock()
+    request.data = request_data
+
+    # テスト対象の実行
+    result = createPrompt(request)
+
+    # 結果の検証
+    assert result == ""
+
+def test_createPrompt_invalid_language_id():
+    # モックの設定
+    request_data = {
+        "prompt": {
+            "appOverview": "test app",
+            "programmingLanguage": 999,
+            "platform": 2,
+            "useDatabase": "true",
+            "useCloud": "true"
+        }
+    }
+    request = MagicMock()
+    request.data = request_data
+
+    # テスト対象の実行
+    result = createPrompt(request)
+
+    # 結果の検証
+    assert result == "存在しない言語です。入力内容を確認してください。"
+
+def test_createPrompt_invalid_platform_id():
+    # モックの設定
+    request_data = {
+        "prompt": {
+            "appOverview": "test app",
+            "programmingLanguage": 1,
+            "platform": 999,  # 存在しないID
+            "useDatabase": "true",
+            "useCloud": "true"
+        }
+    }
+    request = MagicMock()
+    request.data = request_data
+
+    # テスト対象の実行
+    result = createPrompt(request)
+
+    # 結果の検証
+    assert result == "存在しないプラットフォームです。入力内容を確認してください。"
+
+def test_createPrompt_app_overview_exceeds_max_len():
+    # モックの設定
+    long_string = "a" * (MAX_LEN + 1)
+    request_data = {
+        "prompt": {
+            "appOverview": long_string,
+            "programmingLanguage": 1,
+            "platform": 2,
+            "useDatabase": "true",
+            "useCloud": "true"
+        }
+    }
+    request = MagicMock()
+    request.data = request_data
+
+    # テスト対象の実行
+    result = createPrompt(request)
+
+    # 結果の検証
+    assert result == "max_len_error"

--- a/backend/chatgptapi/test/unittest_chatgpt.py
+++ b/backend/chatgptapi/test/unittest_chatgpt.py
@@ -1,0 +1,120 @@
+import os
+from django.conf import settings
+import django
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'devchatrecipe.settings'
+django.setup()
+
+import unittest
+from unittest.mock import patch, MagicMock
+from chatgptapi.services.chatgpt import createPrompt
+
+import sys
+sys.path.append('/backend/chatgptapi')
+
+class TestChatGPT(unittest.TestCase):
+    MAX_LEN = 50
+
+    def test_createPrompt_normal(self):
+        # モックの設定
+        request_data = {
+            "prompt": {
+                "appOverview": "test app",
+                "programmingLanguage": 1,
+                "platform": 2,
+                "useDatabase": "true",
+                "useCloud": "true"
+            }
+        }
+        request = MagicMock()
+        request.data = request_data
+
+        # テスト対象の実行
+        result = createPrompt(request)
+
+        # 結果の検証
+        self.assertIsNotNone(result)
+
+    def test_createPrompt_abnormal(self):
+        # モックの設定
+        request_data = {
+            "prompt": {
+                "appOverview": "",
+                "programmingLanguage": 1,
+                "platform": 2,
+                "useDatabase": "true",
+                "useCloud": "true"
+            }
+        }
+        request = MagicMock()
+        request.data = request_data
+
+        # テスト対象の実行
+        result = createPrompt(request)
+
+        # 結果の検証
+        self.assertEqual(result, "")
+
+    def test_createPrompt_invalid_language_id(self):
+        # モックの設定
+        request_data = {
+            "prompt": {
+                "appOverview": "test app",
+                "programmingLanguage": 999,  # 存在しないID
+                "platform": 2,
+                "useDatabase": "true",
+                "useCloud": "true"
+            }
+        }
+        request = MagicMock()
+        request.data = request_data
+
+        # テスト対象の実行
+        result = createPrompt(request)
+
+        # 結果の検証
+        self.assertEqual(result, "存在しない言語です。入力内容を確認してください。")
+
+    def test_createPrompt_invalid_platform_id(self):
+        # モックの設定
+        request_data = {
+            "prompt": {
+                "appOverview": "test app",
+                "programmingLanguage": 1,
+                "platform": 999,  # 存在しないID
+                "useDatabase": "true",
+                "useCloud": "true"
+            }
+        }
+        request = MagicMock()
+        request.data = request_data
+
+        # テスト対象の実行
+        result = createPrompt(request)
+
+        # 結果の検証
+        self.assertEqual(result, "存在しないプラットフォームです。入力内容を確認してください。")
+
+    def test_createPrompt_app_overview_exceeds_max_len(self):
+        # モックの設定
+        long_string = "a" * (self.MAX_LEN + 1)
+        request_data = {
+            "prompt": {
+                "appOverview": long_string,
+                "programmingLanguage": 1,
+                "platform": 2,
+                "useDatabase": "true",
+                "useCloud": "true"
+            }
+        }
+        request = MagicMock()
+        request.data = request_data
+
+        # テスト対象の実行
+        result = createPrompt(request)
+
+        # 結果の検証
+        self.assertEqual(result, "max_len_error")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/json/platform.json
+++ b/backend/json/platform.json
@@ -3,7 +3,7 @@
     {
       "id": 1,
       "dispname": "指定なし",
-      "prompt": "unspecified"
+      "prompt": "指定なし"
     },
     {
       "id": 2,

--- a/backend/json/programmingLanguage.json
+++ b/backend/json/programmingLanguage.json
@@ -3,7 +3,7 @@
     {
       "id":1,
       "dispName": "指定なし",
-      "prompt": "unspecified"
+      "prompt": "指定なし"
     },
     {
       "id":2,

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = devchatrecipe.settings
+python_files = test_*.py
+filterwarnings = ignore::DeprecationWarning

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ django-filter
 django-cors-headers
 googletrans==4.0.0-rc1
 openai
+pytest
+pytest-django


### PR DESCRIPTION
対応内容
・pytestの実装
・質問処理のエラーハンドリング追加
　存在しない言語を選択した場合
　存在しないプラットフォームを選択した場合
・質問内容のテンプレートを修正（ライブラリを追加）

テスト実行方法
▼unittestの場合
１．PYTHONPATHにbackendのプロジェクトルートを設定
$env:PYTHONPATH="$env:PYTHONPATH;C:\project\dev_chat_recipe_web\backend"
２．上記で設定したプロジェクトルートから以下コマンド実行
python -m unittest chatgptapi/test/unittest_chatgpt.py

▼pytestの場合
１．PYTHONPATHにbackendのプロジェクトルートを設定
$env:PYTHONPATH="$env:PYTHONPATH;C:\project\dev_chat_recipe_web\backend"
２．以下ライブラリをインストール
pip install pytest-django
pip install pytest
※requirements.txtには追加
３．上記で設定したプロジェクトルートから以下コマンド実行
pytest -v chatgptapi/test/pytest_chatgpt.py